### PR TITLE
[FIX] Fix parameters leading to duplicated sources

### DIFF
--- a/pydra2app/core/command/base.py
+++ b/pydra2app/core/command/base.py
@@ -146,7 +146,7 @@ class ContainerCommand:
     @parameters.default  # pyright: ignore[reportAttributeAccessIssue]
     def _default_parameters(self) -> list[str]:
         non_parameters = (
-            self.source_names + list(self.configuration) + [self.task._executor_name]
+            [s.field for s in self.sources] + list(self.configuration) + [self.task._executor_name]
         )
         return [  # pyright: ignore[reportReturnType]
             i.name

--- a/pydra2app/core/command/tests/test_command.py
+++ b/pydra2app/core/command/tests/test_command.py
@@ -425,6 +425,45 @@ def test_shell_command_execute(saved_dataset, work_dir):
                 "parameters[1].help": "",
             },
         ),
+        (
+            {
+                "task": {
+                    "type": "shell",
+                    "executable": [
+                        "my-app",
+                        "<in_file:generic/file>",
+                        "<out|out_file:image/png>",
+                        "--optional-file",
+                        "<optional_file:generic/file?>",
+                        "--template",
+                        "<template:image/png?>",
+                        "--flag<flag>",
+                        "--param",
+                        "<param:int?>",
+                        "--not-needed-file",
+                        "<out|not_needed:generic/file>",
+                    ],
+                },
+                "operates_on": "samples/sample",
+                "sources": {
+                    "an_image": "in_file",
+                    "optional_file": None,
+                },
+                "sinks": {"my_app_out_file": "out_file", "my_app_stdout": "stdout"},
+                # parameters intentionally omitted to test default derivation
+            },
+            {
+                "source_names": ["an_image", "optional_file"],
+                "sink_names": ["my_app_out_file", "my_app_stdout"],
+                # in_file and optional_file should NOT appear in parameters
+                "parameter_names": [
+                    "template",
+                    "flag",
+                    "param",
+                    "append_args",
+                ],
+            },
+        ),
     ],
 )
 def test_command_serialization(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 name = "pydra2app"
 description = "Pydra2App: a tool for quickly turning Pydra tasks into containerised applications (e.g. BIDS Apps or XNAT pipelines)"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.11"
 dependencies = [
     "attrs>=22.1.0",
     "build >=0.9",


### PR DESCRIPTION
Fixes #33 

Auto derived parameters are incorrect when there are custom named sources and no explicit parameters, as it will incorrectly include the source fields. This happens because `_default_parameters()` compares source names (i.e. an_image) against field names (i.e. in_file) so there is a mismatch.

Changed self.source_names to [s.field for s in self.sources] so the exclusion list uses field names, matching the namespace of _input_fields.

Added a parametrise case to test_command_serialization that uses custom named sources with no explicit parameters, verifying source fields don't leak into parameter_names after a YAML roundtrip.