### PR TITLE
Add a standalone pydra2app `plan-builds` command for determining which pipeline specifications require new container images

### DIFF
--- a/docs/source/building.rst
+++ b/docs/source/building.rst
@@ -85,6 +85,34 @@ and attempt to build any YAML_ files it finds, e.g.
     ./config-root-dir/mri/neuro/freesurfer.yml: Freesurfer [recon-all]
     ...
 
+To inspect the tree without building and produce a JSON build matrix, use
+``plan-builds``:
+
+.. code-block:: console
+
+    $ pydra2app plan-builds xnat 'config-root-dir' --registry ghcr.io
+    {
+      "build": [
+        "mri/neuro/fsl"
+      ],
+      "unchanged": [
+        "mri/neuro/freesurfer"
+      ]
+    }
+
+The command fails if a published spec changed without a version increment or if
+the spec version is older than the latest published image.
+
+To inspect only specs selected by a workflow while preserving their paths relative
+to the specification root, repeat ``--spec``. Extensions may be omitted:
+
+.. code-block:: console
+
+    $ pydra2app plan-builds xnat 'config-root-dir' \
+        --registry ghcr.io \
+        --spec quality-control/phi-finder \
+        --spec mri/human/neuro/monai/example
+
 
 
 Autodocs

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -11,6 +11,9 @@ Pydra2Apps's command line interface consists of a number of sub-commands under t
 .. click:: pydra2app.core.cli:make
    :prog: pydra2app make
 
+.. click:: pydra2app.core.cli:plan_builds
+   :prog: pydra2app plan-builds
+
 .. click:: pydra2app.core.cli:make_docs
    :prog: pydra2app make-docs
 

--- a/pydra2app/core/cli.py
+++ b/pydra2app/core/cli.py
@@ -28,6 +28,8 @@ from pydra2app.core.utils import (
 )
 from pydra2app.core.command import entrypoint_opts
 from pydra2app.core import PACKAGE_NAME
+from pydra2app.core.exceptions import Pydra2AppBuildError, Pydra2AppReleaseError
+from pydra2app.core.release import plan_release, ReleaseStatus
 
 logger = logging.getLogger("pydra2app")
 
@@ -38,6 +40,156 @@ logger = logging.getLogger("pydra2app")
 def cli() -> None:
     """Base command line group, installed as "pydra2app"."""
     return None
+
+
+@cli.command(
+    name="plan-builds",
+    help="""Inspect specs and report which container images require a new build.
+
+TARGET is the App type to inspect, such as 'xnat' or 'common:App'.
+
+SPEC_PATH is a specification file or a directory containing specifications.
+""",
+)
+@click.argument("target", type=str)
+@click.argument("spec_path", type=click.Path(exists=True, path_type=Path))
+@click.option(
+    "--spec",
+    "selected_specs",
+    multiple=True,
+    help=(
+        "Only inspect this spec, relative to a SPEC_PATH directory. The .yaml or .yml "
+        "suffix may be omitted. Repeat to inspect multiple selected specs."
+    ),
+)
+@click.option(
+    "--registry",
+    default=DOCKER_HUB,
+    help="The Docker registry containing published pipeline images",
+)
+@click.option(
+    "--spec-root",
+    type=click.Path(path_type=Path, exists=True),
+    default=None,
+    help="The root path specs are relative to; inferred from SPEC_PATH by default",
+)
+@click.option("--loglevel", default="warning", help="The level to display logs at")
+@click.option(
+    "--access-token",
+    type=str,
+    default=None,
+    help="An access token for the Docker registry",
+    envvar="P2A_ACCESS_TOKEN",
+)
+def plan_builds(
+    target: str,
+    spec_path: Path,
+    selected_specs: ty.Sequence[str],
+    registry: str,
+    spec_root: ty.Optional[Path],
+    loglevel: str,
+    access_token: ty.Optional[str],
+) -> None:
+    logging.basicConfig(level=getattr(logging, loglevel.upper()))
+
+    spec_path = spec_path.resolve()
+    if spec_root is None:
+        spec_root = spec_path.parent if spec_path.is_dir() else spec_path.parent.parent
+    else:
+        spec_root = spec_root.resolve()
+
+    paths_to_load = [spec_path]
+    if selected_specs:
+        if not spec_path.is_dir():
+            raise click.UsageError(
+                "--spec can only be used when SPEC_PATH is a directory"
+            )
+        paths_to_load = []
+        selection_root = spec_path.resolve()
+        for selected_spec in selected_specs:
+            relative_path = Path(selected_spec)
+            if relative_path.is_absolute() or ".." in relative_path.parts:
+                raise click.BadParameter(
+                    f"{selected_spec!r} must be relative to SPEC_PATH",
+                    param_hint="--spec",
+                )
+            candidates = (
+                [relative_path]
+                if relative_path.suffix in (".yaml", ".yml")
+                else [
+                    relative_path.with_suffix(".yaml"),
+                    relative_path.with_suffix(".yml"),
+                ]
+            )
+            matches = [
+                spec_path / candidate
+                for candidate in candidates
+                if (spec_path / candidate).is_file()
+            ]
+            if not matches:
+                raise click.BadParameter(
+                    f"Could not find selected spec {selected_spec!r} under SPEC_PATH",
+                    param_hint="--spec",
+                )
+            if len(matches) > 1:
+                raise click.BadParameter(
+                    f"Selected spec {selected_spec!r} matches both .yaml and .yml files",
+                    param_hint="--spec",
+                )
+            selected_path = matches[0].resolve()
+            try:
+                selected_path.relative_to(selection_root)
+            except ValueError:
+                raise click.BadParameter(
+                    f"{selected_spec!r} resolves outside SPEC_PATH",
+                    param_hint="--spec",
+                ) from None
+            paths_to_load.append(selected_path)
+        paths_to_load = sorted(set(paths_to_load))
+
+    target_cls: ty.Type[App] = ClassResolver(App, package=PACKAGE_NAME)(target)
+    with ClassResolver.FALLBACK_TO_STR:
+        image_specs = [
+            image_spec
+            for path_to_load in paths_to_load
+            for image_spec in target_cls.load_tree(
+                path_to_load,
+                root_dir=spec_root,
+                registry=registry,
+                access_token=access_token,
+            )
+        ]
+
+    planned: ty.Dict[str, ty.List[str]] = {
+        ReleaseStatus.BUILD.value: [],
+        ReleaseStatus.UNCHANGED.value: [],
+    }
+    invalid: ty.List[str] = []
+    for image_spec in image_specs:
+        try:
+            decision = plan_release(image_spec)
+        except Pydra2AppBuildError as e:
+            raise click.ClickException(str(e)) from e
+        if spec_path.is_file():
+            spec_name = spec_path.stem
+        else:
+            spec_name = (
+                image_spec.loaded_from.relative_to(spec_path.absolute())
+                .with_suffix("")
+                .as_posix()
+            )
+        if decision.status is ReleaseStatus.INVALID:
+            assert decision.reason is not None
+            invalid.append(decision.reason)
+        else:
+            planned[decision.status.value].append(spec_name)
+
+    if invalid:
+        raise click.ClickException("\n".join(sorted(invalid)))
+
+    for specs in planned.values():
+        specs.sort()
+    click.echo(json.dumps(planned, indent=2))
 
 
 @cli.command(
@@ -411,22 +563,18 @@ def make(
 
     for image_spec in image_specs:
         image_reference = image_spec.reference
-        if (
-            check_registry
-            and image_spec.latest_published
-            and image_spec.latest_published >= image_spec.version
-        ):
-            latest_reference = f"{image_spec.path}:{image_spec.latest_published}"
-            if image_spec.matches_image(latest_reference):
+        if check_registry:
+            decision = plan_release(image_spec)
+            if decision.status is ReleaseStatus.UNCHANGED:
                 logger.info(
                     "Skipping '%s' build as identical image already exists in registry '%s'",
                     image_reference,
-                    latest_reference,
+                    f"{image_spec.path}:{decision.published_version}",
                 )
                 continue
-            image_reference = (
-                f"{image_spec.path}:{image_spec.latest_published.bump_postfix()}"
-            )
+            if decision.status is ReleaseStatus.INVALID:
+                assert decision.reason is not None
+                raise Pydra2AppReleaseError(decision.reason)
 
         spec_build_dir = (
             build_dir / image_spec.loaded_from.relative_to(spec_path.absolute())

--- a/pydra2app/core/exceptions.py
+++ b/pydra2app/core/exceptions.py
@@ -24,6 +24,10 @@ class Pydra2AppVersionError(Pydra2AppError):
     pass
 
 
+class Pydra2AppReleaseError(Pydra2AppVersionError):
+    pass
+
+
 class Pydra2AppRequirementNotFoundError(Pydra2AppVersionError):
     pass
 

--- a/pydra2app/core/image/app.py
+++ b/pydra2app/core/image/app.py
@@ -358,7 +358,8 @@ class App(P2AImage):
             return [cls.load(spec_path, root_dir=root_dir, **kwargs)]
         specs = []
         for path in chain(spec_path.rglob("*.yml"), spec_path.rglob("*.yaml")):
-            if not any(p.startswith(".") for p in path.parts):
+            relative_path = path.relative_to(spec_path)
+            if not any(p.startswith(".") for p in relative_path.parts):
                 logging.info("Found container image specification file '%s'", path)
                 specs.append(cls.load(path, root_dir=root_dir, **kwargs))
 

--- a/pydra2app/core/image/base.py
+++ b/pydra2app/core/image/base.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 import typing as ty
 from pathlib import PurePath, Path, PosixPath
+from urllib.parse import quote
 import json
 import re
 import tempfile
@@ -192,15 +193,34 @@ class P2AImage:
                 "Fetching tags for '%s' from GitHub Container Registry with access token",
                 self.path,
             )
-            url = f"https://api.github.com/orgs/{self.org}/packages/container/{self.name}/versions"
+            url = (
+                f"https://api.github.com/orgs/{quote(self.org or '', safe='')}"
+                f"/packages/container/{quote(self.name, safe='')}/versions"
+            )
             headers = {
                 "Accept": "application/vnd.github.v3+json",
                 "Authorization": f"Bearer {self.access_token}",
             }
-            response = requests.get(url, headers=headers)
-            if response.status_code != 200:
-                response.raise_for_status()
-            tags = [p["metadata"]["container"]["tags"][0] for p in response.json()]
+            tags = []
+            params: ty.Optional[ty.Dict[str, int]] = {"per_page": 100}
+            while url:
+                response = requests.get(url, headers=headers, params=params)
+                if response.status_code == 404:
+                    raise Pydra2AppBuildError(
+                        f"Could not confirm whether GHCR package '{self.path}' exists: "
+                        "GitHub returned 404, which can mean either that the package "
+                        "does not exist or that the access token cannot read it"
+                    )
+                if response.status_code != 200:
+                    response.raise_for_status()
+                for package_version in response.json():
+                    tags.extend(
+                        package_version.get("metadata", {})
+                        .get("container", {})
+                        .get("tags", [])
+                    )
+                url = response.links.get("next", {}).get("url")
+                params = None
         else:
             logger.info("Fetching tags for '%s' from %s", self.path, self.registry)
             protocol = "http" if self.registry.startswith("localhost") else "https"
@@ -222,7 +242,18 @@ class P2AImage:
             self.path,
             published_tags,
         )
-        versions = sorted(Version.parse(t) for t in published_tags)
+        versions = []
+        for tag in published_tags:
+            version = Version.parse(tag)
+            try:
+                version.compare(self.version)
+            except ValueError:
+                logger.debug(
+                    "Ignoring non-version tag '%s' for '%s'", tag, self.path
+                )
+            else:
+                versions.append(version)
+        versions.sort()
         return versions[-1] if versions else None
 
     def matches_image(self, image_reference: str) -> bool:

--- a/pydra2app/core/image/tests/test_image.py
+++ b/pydra2app/core/image/tests/test_image.py
@@ -1,11 +1,13 @@
 import typing as ty
 from pathlib import Path
 import random
+from unittest.mock import Mock
 import docker.errors
 import os
 import logging
 from copy import copy
 from traceback import format_exc
+from pydra2app.core.exceptions import Pydra2AppBuildError
 from pydra2app.core.image import App
 from pydra2app.core.image.components import Version
 from pydra2app.core.utils import DOCKER_HUB, GITHUB_CONTAINER_REGISTRY
@@ -139,3 +141,59 @@ def test_registry_tags(
 
     app = App(registry=docker_registry, **image_spec_cpy)
     assert sorted(app.registry_tags()) == sorted(image_tags)
+
+
+def test_ghcr_registry_tags_ignores_untagged_and_paginates(
+    image_spec: ty.Dict[str, ty.Any], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    first_response = Mock(
+        status_code=200,
+        links={"next": {"url": "https://api.github.com/next-page"}},
+    )
+    first_response.json.return_value = [
+        {"metadata": {"container": {"tags": []}}},
+        {"metadata": {"container": {"tags": ["1.0.0", "latest"]}}},
+    ]
+    second_response = Mock(status_code=200, links={})
+    second_response.json.return_value = [
+        {"metadata": {"container": {"tags": ["1.1.0"]}}},
+    ]
+    get = Mock(side_effect=[first_response, second_response])
+    monkeypatch.setattr("pydra2app.core.image.base.requests.get", get)
+    app = App(
+        registry=GITHUB_CONTAINER_REGISTRY,
+        access_token="token",
+        **image_spec,
+    )
+
+    assert app.registry_tags() == ["1.0.0", "latest", "1.1.0"]
+    assert get.call_args_list[0].kwargs["params"] == {"per_page": 100}
+    assert get.call_args_list[1].kwargs["params"] is None
+
+
+def test_ghcr_registry_tags_fails_safely_on_ambiguous_404(
+    image_spec: ty.Dict[str, ty.Any], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        "pydra2app.core.image.base.requests.get",
+        Mock(return_value=Mock(status_code=404)),
+    )
+    app = App(
+        registry=GITHUB_CONTAINER_REGISTRY,
+        access_token="token",
+        **image_spec,
+    )
+
+    with pytest.raises(Pydra2AppBuildError, match="does not exist or"):
+        app.registry_tags()
+
+
+def test_latest_published_ignores_non_version_tags(
+    image_spec: ty.Dict[str, ty.Any], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    app = App(**image_spec)
+    monkeypatch.setattr(
+        App, "registry_tags", Mock(return_value=["1.0.0", "latest"])
+    )
+
+    assert app.latest_published == Version.parse("1.0.0")

--- a/pydra2app/core/release.py
+++ b/pydra2app/core/release.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import typing as ty
+from dataclasses import dataclass
+from enum import Enum
+
+from pydra2app.core.image import App
+from pydra2app.core.image.components import Version
+
+
+class ReleaseStatus(str, Enum):
+    BUILD = "build"
+    UNCHANGED = "unchanged"
+    INVALID = "invalid"
+
+
+@dataclass(frozen=True)
+class ReleaseDecision:
+    status: ReleaseStatus
+    app: App
+    published_version: ty.Optional[Version] = None
+    reason: ty.Optional[str] = None
+
+
+def plan_release(app: App) -> ReleaseDecision:
+    """Determine whether an app spec requires a new image build."""
+    published_version = app.latest_published
+    if published_version is None or app.version > published_version:
+        return ReleaseDecision(
+            status=ReleaseStatus.BUILD,
+            app=app,
+            published_version=published_version,
+        )
+
+    if app.version < published_version:
+        return ReleaseDecision(
+            status=ReleaseStatus.INVALID,
+            app=app,
+            published_version=published_version,
+            reason=(
+                f"Version decreased for '{app.name}': spec version {app.version} is "
+                f"older than published version {published_version}"
+            ),
+        )
+
+    published_reference = f"{app.path}:{published_version}"
+    if app.matches_image(published_reference):
+        return ReleaseDecision(
+            status=ReleaseStatus.UNCHANGED,
+            app=app,
+            published_version=published_version,
+        )
+
+    return ReleaseDecision(
+        status=ReleaseStatus.INVALID,
+        app=app,
+        published_version=published_version,
+        reason=(
+            f"Spec changed for '{app.name}' without a version increment: "
+            f"{app.version} is already published"
+        ),
+    )

--- a/pydra2app/core/tests/test_cli.py
+++ b/pydra2app/core/tests/test_cli.py
@@ -148,13 +148,10 @@ def test_deploy_remake_cli(command_spec, local_docker_registry, cli_runner, run_
         # is a clash)
         concatenate_spec["packages"] = {"system": ["vim", "git"]}
 
-        result = build_spec(concatenate_spec, catch_exceptions=False)
+        result = build_spec(concatenate_spec)
 
-        # Check that the image was rebuilt with an incremented tag
-        assert result.exit_code == 0, show_cli_trace(result)
-        rebuilt_tag = result.output.strip().splitlines()[-1]
-        assert rebuilt_tag.split(":")[-1] == "1.0-post1"
-        dc.images.remove(rebuilt_tag)
+        assert result.exit_code == 1
+        assert "without a version increment" in str(result.exception)
     finally:
         # Clean up the built images
         dc.images.remove(tag)

--- a/pydra2app/core/tests/test_release.py
+++ b/pydra2app/core/tests/test_release.py
@@ -1,0 +1,195 @@
+import json
+from pathlib import Path
+from unittest.mock import Mock, PropertyMock
+
+import pytest
+from click.testing import CliRunner
+
+from pydra2app.core.cli import make, plan_builds
+from pydra2app.core.exceptions import Pydra2AppBuildError, Pydra2AppReleaseError
+from pydra2app.core.image import App
+from pydra2app.core.image.components import Version
+from pydra2app.core.release import plan_release, ReleaseStatus
+
+
+def app(
+    current: str,
+    published: str | None,
+    *,
+    matches: bool = False,
+    name: str = "example",
+) -> Mock:
+    image_spec = Mock()
+    image_spec.name = name
+    image_spec.path = f"registry.example/org/{name}"
+    image_spec.version = Version.parse(current)
+    image_spec.latest_published = (
+        Version.parse(published) if published is not None else None
+    )
+    image_spec.matches_image.return_value = matches
+    image_spec.loaded_from = Path(f"/specs/{name}.yaml")
+    return image_spec
+
+
+@pytest.mark.parametrize(
+    ("current", "published"),
+    [("1.0", None), ("1.1", "1.0")],
+)
+def test_plan_release_builds_new_image(current: str, published: str | None) -> None:
+    image_spec = app(current, published)
+
+    decision = plan_release(image_spec)
+
+    assert decision.status is ReleaseStatus.BUILD
+    image_spec.matches_image.assert_not_called()
+
+
+def test_plan_release_skips_unchanged_image() -> None:
+    image_spec = app("1.0", "1.0", matches=True)
+
+    decision = plan_release(image_spec)
+
+    assert decision.status is ReleaseStatus.UNCHANGED
+    image_spec.matches_image.assert_called_once_with(
+        "registry.example/org/example:1.0"
+    )
+
+
+def test_plan_release_rejects_changed_spec_without_version_increment() -> None:
+    decision = plan_release(app("1.0", "1.0", matches=False))
+
+    assert decision.status is ReleaseStatus.INVALID
+    assert "without a version increment" in decision.reason
+
+
+def test_plan_release_rejects_version_decrease() -> None:
+    image_spec = app("1.0", "1.1")
+
+    decision = plan_release(image_spec)
+
+    assert decision.status is ReleaseStatus.INVALID
+    assert "Version decreased" in decision.reason
+    image_spec.matches_image.assert_not_called()
+
+
+def test_plan_builds_selected_specs_preserve_relative_paths(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    spec_path = tmp_path / "specs" / "org"
+    selected_paths = [
+        spec_path / "quality-control" / "phi-finder.yaml",
+        spec_path / "mri" / "human" / "neuro" / "preprocess.yml",
+    ]
+    disabled_path = spec_path / "disabled.yaml"
+    for path in selected_paths + [disabled_path]:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.touch()
+
+    image_specs = {}
+    for path in selected_paths:
+        image_spec = app("1.0", None, name=path.stem)
+        image_spec.loaded_from = path.absolute()
+        image_specs[path.resolve()] = image_spec
+
+    loaded_paths = []
+
+    def load_tree(
+        cls: type[App], path: Path, **kwargs: object
+    ) -> list[Mock]:
+        loaded_paths.append(path)
+        assert kwargs["root_dir"] == spec_path.parent
+        return [image_specs[path.resolve()]]
+
+    monkeypatch.setattr(App, "load_tree", classmethod(load_tree))
+
+    result = CliRunner().invoke(
+        plan_builds,
+        [
+            "common:App",
+            str(spec_path),
+            "--spec",
+            "quality-control/phi-finder",
+            "--spec",
+            "mri/human/neuro/preprocess.yml",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert json.loads(result.output) == {
+        "build": [
+            "mri/human/neuro/preprocess",
+            "quality-control/phi-finder",
+        ],
+        "unchanged": [],
+    }
+    assert loaded_paths == sorted(selected_paths)
+
+
+def test_plan_builds_rejects_missing_selected_spec(tmp_path: Path) -> None:
+    spec_path = tmp_path / "specs"
+    spec_path.mkdir()
+
+    result = CliRunner().invoke(
+        plan_builds,
+        ["common:App", str(spec_path), "--spec", "missing"],
+    )
+
+    assert result.exit_code == 2
+    assert "Could not find selected spec 'missing'" in result.output
+
+
+def test_plan_builds_reports_registry_access_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    spec_path = tmp_path / "specs"
+    spec_path.mkdir()
+    image_spec = app("1.0", None)
+    image_spec.loaded_from = spec_path / "example.yaml"
+    monkeypatch.setattr(
+        type(image_spec),
+        "latest_published",
+        PropertyMock(
+            side_effect=Pydra2AppBuildError(
+                "Registry access could not be confirmed"
+            )
+        ),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        App,
+        "load_tree",
+        classmethod(lambda cls, *args, **kwargs: [image_spec]),
+    )
+
+    result = CliRunner().invoke(plan_builds, ["common:App", str(spec_path)])
+
+    assert result.exit_code == 1
+    assert result.output == "Error: Registry access could not be confirmed\n"
+    assert isinstance(result.exception, SystemExit)
+
+
+def test_make_check_registry_reuses_release_rules(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    spec_path = tmp_path / "org"
+    loaded_from = spec_path / "package" / "changed.yaml"
+    loaded_from.parent.mkdir(parents=True)
+    loaded_from.touch()
+    image_spec = app("1.0", "1.0", matches=False, name="package.changed")
+    image_spec.loaded_from = loaded_from
+    monkeypatch.setattr(
+        App,
+        "load_tree",
+        classmethod(lambda cls, *args, **kwargs: [image_spec]),
+    )
+    monkeypatch.setattr("pydra2app.core.cli.docker.from_env", Mock())
+
+    result = CliRunner().invoke(
+        make,
+        ["common:App", str(spec_path), "--check-registry"],
+    )
+
+    assert result.exit_code == 1
+    assert isinstance(result.exception, Pydra2AppReleaseError)
+    assert "without a version increment" in str(result.exception)
+    image_spec.make.assert_not_called()


### PR DESCRIPTION
The command checks published registry versions and reports:

• New pipelines that need building.
• Version-incremented pipelines that need building.
• Unchanged pipelines that can be skipped.
• Invalid pipelines whose specs changed without a version increment.
• Invalid pipelines whose versions decreased.

It outputs JSON suitable for use as a GitHub Actions build matrix

One thing in particular is that the existing  make `--check-registry` flow was automatically creating a -postN version for missing version increments. It now reuses the same release logic and will reject missing version increments. If this is not wanted let me know

Also added catch for 404 errors instead of building automatically

The next subissue will integrate `plan-builds` into the pipelines repository

Will close the sub issue within pipelines